### PR TITLE
gen_swupdate.py: fix libconfig include path

### DIFF
--- a/gen_swupdate.py
+++ b/gen_swupdate.py
@@ -127,14 +127,14 @@ def main():
     opt.output = os.path.abspath(opt.output)
     opt.libdirs = [os.path.abspath(p) for p in opt.libdirs]
 
+    fp = codecs.open(swdescription_in, 'r', 'utf-8')
+    cc = libconf.load(fp, filename=swdescription_in)
+
     if not opt.chdir:
         temp = TemporaryDirectory()
         opt.chdir = temp.name
 
     os.chdir(opt.chdir)
-
-    fp = codecs.open(swdescription_in, 'r', 'utf-8')
-    cc = libconf.load(fp, filename=swdescription_in)
 
     for i in find_key('images', cc.software):
         handle_image(i, opt)


### PR DESCRIPTION
There is no need to switch to temporary directory before parsing the template. There is also the possibility to use the (absolute) template directory in libconf.parse(), but moving the change of the working directory also works fine.
